### PR TITLE
Fix Vercel build source

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "builds": [
     {
-      "src": "frontend2/next.config.ts",
+      "src": "frontend2/package.json",
       "use": "@vercel/next"
     }
   ]


### PR DESCRIPTION
## Summary
- fix `vercel.json` so `@vercel/next` uses the package.json

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859e3e6e5048325943e0d9de2b57c41