### PR TITLE
Integrate Travelpayouts API example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SEARCH_API_URL=https://api.travelpayouts.com/aviasales/v3/prices_for_dates
+SEARCH_API_KEY=your_travelpayouts_api_key

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ ShayFly הוא פרויקט לדוגמה המדגים מנוע חיפוש דיל
    ```
 2. יצירת קובץ `.env.local` עם משתנים:
    ```bash
-   SEARCH_API_URL=https://example.com/api
-   SEARCH_API_KEY=your_key_here
+   SEARCH_API_URL=https://api.travelpayouts.com/aviasales/v3/prices_for_dates
+   SEARCH_API_KEY=<YOUR_TRAVELPAYOUTS_API_KEY>
    ```
 3. הרצת סביבה לפיתוח:
    ```bash

--- a/frontend2/app/api/search/route.ts
+++ b/frontend2/app/api/search/route.ts
@@ -14,12 +14,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'API configuration missing' }, { status: 500 });
   }
 
-  const url = `${apiUrl}?origin=${origin}&destination=${destination}&departDate=${departDate}&returnDate=${returnDate}&passengers=${passengers}`;
+  // Travelpayouts API expects token as a query parameter
+  const url = `${apiUrl}?origin=${origin}&destination=${destination}&depart_date=${departDate}&return_date=${returnDate}&passengers=${passengers}&token=${apiKey}`;
 
   try {
-    const apiResponse = await fetch(url, {
-      headers: { 'Authorization': `Bearer ${apiKey}` }
-    });
+    const apiResponse = await fetch(url);
     const data = await apiResponse.json();
     return NextResponse.json(data);
   } catch (err) {


### PR DESCRIPTION
## Summary
- update README with Travelpayouts environment variables
- add example `.env` file
- adjust API route to use Travelpayouts token query parameter

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859e6cbebf483258d311e7e8dc6bafc