### PR TITLE
Fix API caching and add error handling

### DIFF
--- a/frontend2/.env.example
+++ b/frontend2/.env.example
@@ -1,0 +1,2 @@
+SEARCH_API_URL=https://example.com/api
+SEARCH_API_KEY=your_key_here

--- a/frontend2/app/api/search/route.ts
+++ b/frontend2/app/api/search/route.ts
@@ -1,4 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -14,15 +16,22 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'API configuration missing' }, { status: 500 });
   }
 
-  const url = `${apiUrl}?origin=${origin}&destination=${destination}&departDate=${departDate}&returnDate=${returnDate}&passengers=${passengers}`;
+  const url = `${apiUrl}?origin=${origin}&destination=${destination}&departDate=${departDate}&returnDate=${returnDate}&passengers=${passengers}`
 
   try {
     const apiResponse = await fetch(url, {
-      headers: { 'Authorization': `Bearer ${apiKey}` }
-    });
-    const data = await apiResponse.json();
-    return NextResponse.json(data);
+      headers: { Authorization: `Bearer ${apiKey}` },
+      cache: 'no-store',
+    })
+    if (!apiResponse.ok) {
+      return NextResponse.json(
+        { error: 'Upstream error' },
+        { status: apiResponse.status }
+      )
+    }
+    const data = await apiResponse.json()
+    return NextResponse.json(data)
   } catch (err) {
-    return NextResponse.json({ error: 'Failed to fetch' }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to fetch' }, { status: 500 })
   }
 }

--- a/frontend2/app/page.tsx
+++ b/frontend2/app/page.tsx
@@ -9,9 +9,11 @@ export default function Home() {
   const [passengers, setPassengers] = useState(1)
   const [results, setResults] = useState<any>(null)
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   async function search() {
     setLoading(true)
+    setError(null)
     try {
       const params = new URLSearchParams({
         origin,
@@ -21,10 +23,12 @@ export default function Home() {
         passengers: String(passengers)
       })
       const res = await fetch(`/api/search?${params}`)
+      if (!res.ok) throw new Error('Request failed')
       const data = await res.json()
       setResults(data)
     } catch (e) {
       console.error(e)
+      setError('Failed to fetch results')
     } finally {
       setLoading(false)
     }
@@ -41,6 +45,7 @@ export default function Home() {
         <input className="border p-2" type="number" min="1" value={passengers} onChange={e=>setPassengers(Number(e.target.value))} />
         <button className="bg-blue-600 text-white p-2" onClick={search} disabled={loading}>{loading? 'Searching...' : 'Search'}</button>
       </div>
+      {error && <p className="text-red-500 mt-4">{error}</p>}
       {results && (
         <pre className="text-left mt-6 w-full max-w-2xl overflow-auto bg-gray-100 p-4">
           {JSON.stringify(results, null, 2)}


### PR DESCRIPTION
## Summary
- add explicit dynamic mode and no-store cache to API route
- handle upstream API errors
- improve search page error handling in the client
- add `.env.example` with required vars

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859f2ab07108325839369eae956dac8